### PR TITLE
Switch context-related API to Beta, we can remove these classes if needed

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/securityinspector/UserContext.java
+++ b/src/main/java/org/jenkinsci/plugins/securityinspector/UserContext.java
@@ -30,9 +30,10 @@ import java.util.List;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-@Restricted(NoExternalUse.class)
+@Restricted(Beta.class)
 public class UserContext {
 
     @CheckForNull

--- a/src/main/java/org/jenkinsci/plugins/securityinspector/UserContextCache.java
+++ b/src/main/java/org/jenkinsci/plugins/securityinspector/UserContextCache.java
@@ -33,8 +33,10 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import static org.jenkinsci.plugins.securityinspector.SecurityInspectorAction.getSessionId;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
+@Restricted(Beta.class)
 public class UserContextCache {
 
     //TODO: fix concurrency issues


### PR DESCRIPTION
Classes are used only in the Ownership Plugin. New Plugin POM allows using Beta APIs, and I would like to use such approach here to limit the API exposure.
