### PR TITLE
Use GitHub as a source of plugin documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <artifactId>security-inspector</artifactId>
     <version>0.6-SNAPSHOT</version>
     <packaging>hpi</packaging>
-    <url>https://wiki.jenkins.io/display/JENKINS/Security+Inspector+Plugin</url>
+    <url>https://github.com/jenkinsci/security-inspector-plugin</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
See https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/