### PR TITLE
set configuration category

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/securityinspector/SecurityInspectorAction.java
+++ b/src/main/java/org/jenkinsci/plugins/securityinspector/SecurityInspectorAction.java
@@ -59,6 +59,10 @@ public class SecurityInspectorAction extends ManagementLink {
         return "security-inspector";
     }
 
+    public String getCategoryName() {
+        return "SECURITY";
+    }
+
     @CheckForNull
     @Restricted(NoExternalUse.class)
     public ReportBuilder getDynamic(@Nonnull String buiderName) {


### PR DESCRIPTION
For Jenkins 2.226+, move the "Security Inspector" into the "Security" category.

See jenkinsci/jenkins#4546 for details about this new categories system.

See jenkinsci/configuration-as-code-plugin#1357, or jenkinsci/credentials-plugin#139 + jenkinsci/credentials-plugin#140 for examples of how it has been implemented in other plugins.

Note that implementing this does not require bumping jenkins core dependency to a recent version, so the change proposed here is really minimal.