### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 /work/
+.idea

--- a/src/main/resources/org/jenkinsci/plugins/securityinspector/model/ReportBuilder/createReport.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/securityinspector/model/ReportBuilder/createReport.jelly
@@ -27,7 +27,6 @@
         <st:include it="${app}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>
-                <img src="${imagesURL}/48x48/secure.png" alt="${%Security Inspector}"/>
                 ${%Security Inspector}
             </h1>
             <h3>

--- a/src/main/resources/org/jenkinsci/plugins/securityinspector/model/ReportBuilder/report.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/securityinspector/model/ReportBuilder/report.jelly
@@ -30,7 +30,6 @@
             <link rel="stylesheet" href="${rootURL}/plugin/security-inspector/css/security-inspector.css" type="text/css" />   
             
             <h1>
-                <img src="${imagesURL}/48x48/secure.png" alt="${%Security Inspector}"/>
                 ${%Security Inspector}
             </h1>
              


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.
I ended up with removing headline images here, because that is what core itself does now look like.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @oleg-nenashev 
Thanks in advance!